### PR TITLE
Fixed bugs in CU1_GATE() and CU3_GATE()

### DIFF
--- a/src/dmsim_amdgpu_mpi.hpp
+++ b/src/dmsim_amdgpu_mpi.hpp
@@ -1544,7 +1544,7 @@ __device__ void CRZ_GATE(const Simulation* sim, ValType* dm_real, ValType* dm_im
 __device__ void CU1_GATE(const Simulation* sim, ValType* dm_real, ValType* dm_imag,
         const ValType lambda, const IdxType a, const IdxType b)
 {
-    U1_GATE(sim, dm_real, dm_imag, lambda/2, b);
+    U1_GATE(sim, dm_real, dm_imag, lambda/2, a);
     CX_GATE(sim, dm_real, dm_imag, a, b);
     U1_GATE(sim, dm_real, dm_imag, -lambda/2, b);
     CX_GATE(sim, dm_real, dm_imag, a, b);
@@ -1560,6 +1560,7 @@ __device__ void CU3_GATE(const Simulation* sim, ValType* dm_real, ValType* dm_im
     ValType temp1 = (lambda-phi)/2;
     ValType temp2 = theta/2;
     ValType temp3 = -(phi+lambda)/2;
+    U1_GATE(sim, dm_real, dm_imag, -temp3, c);
     U1_GATE(sim, dm_real, dm_imag, temp1, t);
     CX_GATE(sim, dm_real, dm_imag, c, t);
     U3_GATE(sim, dm_real, dm_imag, -temp2, 0, temp3, t);

--- a/src/dmsim_amdgpu_omp.hpp
+++ b/src/dmsim_amdgpu_omp.hpp
@@ -1544,7 +1544,7 @@ __device__ void CRZ_GATE(const Simulation* sim, ValType* dm_real, ValType* dm_im
 __device__ void CU1_GATE(const Simulation* sim, ValType* dm_real, ValType* dm_imag,
         const ValType lambda, const IdxType a, const IdxType b)
 {
-    U1_GATE(sim, dm_real, dm_imag, lambda/2, b);
+    U1_GATE(sim, dm_real, dm_imag, lambda/2, a);
     CX_GATE(sim, dm_real, dm_imag, a, b);
     U1_GATE(sim, dm_real, dm_imag, -lambda/2, b);
     CX_GATE(sim, dm_real, dm_imag, a, b);
@@ -1560,6 +1560,7 @@ __device__ void CU3_GATE(const Simulation* sim, ValType* dm_real, ValType* dm_im
     ValType temp1 = (lambda-phi)/2;
     ValType temp2 = theta/2;
     ValType temp3 = -(phi+lambda)/2;
+    U1_GATE(sim, dm_real, dm_imag, -temp3, c);
     U1_GATE(sim, dm_real, dm_imag, temp1, t);
     CX_GATE(sim, dm_real, dm_imag, c, t);
     U3_GATE(sim, dm_real, dm_imag, -temp2, 0, temp3, t);

--- a/src/dmsim_cpu_mpi.hpp
+++ b/src/dmsim_cpu_mpi.hpp
@@ -2428,7 +2428,7 @@ void CRZ_GATE(const Simulation* sim, ValType* dm_real, ValType* dm_imag,
 void CU1_GATE(const Simulation* sim, ValType* dm_real, ValType* dm_imag,
         const ValType lambda, const IdxType a, const IdxType b)
 {
-    U1_GATE(sim, dm_real, dm_imag, lambda/2, b);
+    U1_GATE(sim, dm_real, dm_imag, lambda/2, a);
     CX_GATE(sim, dm_real, dm_imag, a, b);
     U1_GATE(sim, dm_real, dm_imag, -lambda/2, b);
     CX_GATE(sim, dm_real, dm_imag, a, b);
@@ -2444,6 +2444,7 @@ void CU3_GATE(const Simulation* sim, ValType* dm_real, ValType* dm_imag,
     ValType temp1 = (lambda-phi)/2;
     ValType temp2 = theta/2;
     ValType temp3 = -(phi+lambda)/2;
+    U1_GATE(sim, dm_real, dm_imag, -temp3, c);
     U1_GATE(sim, dm_real, dm_imag, temp1, t);
     CX_GATE(sim, dm_real, dm_imag, c, t);
     U3_GATE(sim, dm_real, dm_imag, -temp2, 0, temp3, t);

--- a/src/dmsim_cpu_omp.hpp
+++ b/src/dmsim_cpu_omp.hpp
@@ -2476,7 +2476,7 @@ void CRZ_GATE(const Simulation* sim, ValType* dm_real, ValType* dm_imag,
 void CU1_GATE(const Simulation* sim, ValType* dm_real, ValType* dm_imag,
         const ValType lambda, const IdxType a, const IdxType b)
 {
-    U1_GATE(sim, dm_real, dm_imag, lambda/2, b);
+    U1_GATE(sim, dm_real, dm_imag, lambda/2, a);
     CX_GATE(sim, dm_real, dm_imag, a, b);
     U1_GATE(sim, dm_real, dm_imag, -lambda/2, b);
     CX_GATE(sim, dm_real, dm_imag, a, b);
@@ -2492,6 +2492,7 @@ void CU3_GATE(const Simulation* sim, ValType* dm_real, ValType* dm_imag,
     ValType temp1 = (lambda-phi)/2;
     ValType temp2 = theta/2;
     ValType temp3 = -(phi+lambda)/2;
+    U1_GATE(sim, dm_real, dm_imag, -temp3, c);
     U1_GATE(sim, dm_real, dm_imag, temp1, t);
     CX_GATE(sim, dm_real, dm_imag, c, t);
     U3_GATE(sim, dm_real, dm_imag, -temp2, 0, temp3, t);

--- a/src/dmsim_nvgpu_mpi.cuh
+++ b/src/dmsim_nvgpu_mpi.cuh
@@ -1485,7 +1485,7 @@ __device__ __inline__ void CRZ_GATE(const Simulation* sim, ValType* dm_real, Val
 __device__ __inline__ void CU1_GATE(const Simulation* sim, ValType* dm_real, ValType* dm_imag,
         const ValType lambda, const IdxType a, const IdxType b)
 {
-    U1_GATE(sim, dm_real, dm_imag, lambda/2, b);
+    U1_GATE(sim, dm_real, dm_imag, lambda/2, a);
     CX_GATE(sim, dm_real, dm_imag, a, b);
     U1_GATE(sim, dm_real, dm_imag, -lambda/2, b);
     CX_GATE(sim, dm_real, dm_imag, a, b);
@@ -1501,6 +1501,7 @@ __device__ __inline__ void CU3_GATE(const Simulation* sim, ValType* dm_real, Val
     ValType temp1 = (lambda-phi)/2;
     ValType temp2 = theta/2;
     ValType temp3 = -(phi+lambda)/2;
+    U1_GATE(sim, dm_real, dm_imag, -temp3, c);
     U1_GATE(sim, dm_real, dm_imag, temp1, t);
     CX_GATE(sim, dm_real, dm_imag, c, t);
     U3_GATE(sim, dm_real, dm_imag, -temp2, 0, temp3, t);

--- a/src/dmsim_nvgpu_omp.cuh
+++ b/src/dmsim_nvgpu_omp.cuh
@@ -1542,7 +1542,7 @@ __device__ __inline__ void CRZ_GATE(const Simulation* sim, ValType* dm_real, Val
 __device__ __inline__ void CU1_GATE(const Simulation* sim, ValType* dm_real, ValType* dm_imag,
         const ValType lambda, const IdxType a, const IdxType b)
 {
-    U1_GATE(sim, dm_real, dm_imag, lambda/2, b);
+    U1_GATE(sim, dm_real, dm_imag, lambda/2, a);
     CX_GATE(sim, dm_real, dm_imag, a, b);
     U1_GATE(sim, dm_real, dm_imag, -lambda/2, b);
     CX_GATE(sim, dm_real, dm_imag, a, b);
@@ -1558,6 +1558,7 @@ __device__ __inline__ void CU3_GATE(const Simulation* sim, ValType* dm_real, Val
     ValType temp1 = (lambda-phi)/2;
     ValType temp2 = theta/2;
     ValType temp3 = -(phi+lambda)/2;
+    U1_GATE(sim, dm_real, dm_imag, -temp3, c);
     U1_GATE(sim, dm_real, dm_imag, temp1, t);
     CX_GATE(sim, dm_real, dm_imag, c, t);
     U3_GATE(sim, dm_real, dm_imag, -temp2, 0, temp3, t);


### PR DESCRIPTION
Fixed bugs in CU1_GATE() and CU3_GATE() in src/dmsim*.* files.

Lately, I started using this simulator in my projects and noticed that the CU1 and CU3 gate implementations have bugs since they didn't work as I expected. I figured out the bugs and fixed them. My new update is compared with Qiskit's implementation.

Your CU1 implementation had a problem in the target qubit applying U1.
Your CU3 implementation missed one U1 gate.

After updating the implementation as suggested by this PR, my circuits work well.
If you have other opinions or comments, you can reach out to me through "yukwangmin@gmail.com" or "kyu@bnl.gov".


